### PR TITLE
Fix a bug when using a default scope with the facet filter.

### DIFF
--- a/lib/forty_facets/filter/facet_filter_definition.rb
+++ b/lib/forty_facets/filter/facet_filter_definition.rb
@@ -25,7 +25,7 @@ module FortyFacets
 
     class AssociationFacetFilter < FacetFilter
       def selected
-        @selected ||= definition.association.klass.find(Array.wrap(values).reject(&:blank?))
+        @selected ||= definition.association.klass.unscoped.find(Array.wrap(values).reject(&:blank?))
       end
 
       def remove(entity)
@@ -101,7 +101,7 @@ module FortyFacets
         query = "#{my_column} AS foreign_id, count(#{my_column}) AS occurrences"
         counts = without.result(skip_ordering: true).distinct.joins(definition.joins).select(query).group(my_column)
         counts.includes_values = []
-        entities_by_id = definition.association.klass.find(counts.map(&:foreign_id)).group_by(&:id)
+        entities_by_id = definition.association.klass.unscoped.find(counts.map(&:foreign_id)).group_by(&:id)
 
         facet = counts.map do |count|
           facet_entity = entities_by_id[count.foreign_id].first
@@ -138,7 +138,7 @@ module FortyFacets
                   .select("#{my_column} as foreign_id, count(#{my_column}) as occurrences")
                   .group(my_column)
         counts.includes_values = []
-        entities_by_id = definition.association.klass.find(counts.map(&:foreign_id)).group_by(&:id)
+        entities_by_id = definition.association.klass.unscoped.find(counts.map(&:foreign_id)).group_by(&:id)
 
         facet = counts.map do |count|
           facet_entity = entities_by_id[count.foreign_id].first

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema.define do
     t.string :status
     t.string :name
     t.string :description
+    t.datetime :deleted_at
   end
 
   create_table :producers do |t|
@@ -79,10 +80,13 @@ end
 class Studio < ActiveRecord::Base
   belongs_to :country
   has_and_belongs_to_many :producers
+
+  default_scope ->{ where(deleted_at: nil) }
+  scope :with_deleted, ->{ unscope(where: :deleted_at) }
 end
 
 class Movie < ActiveRecord::Base
-  belongs_to :studio
+  belongs_to :studio, ->{ with_deleted }
   has_and_belongs_to_many :genres
   has_and_belongs_to_many :actors
   has_and_belongs_to_many :writers

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -2,8 +2,9 @@ require 'coveralls'
 Coveralls.wear!
 
 require "minitest/autorun"
+require 'test_helper'
 require 'logger'
-#require 'byebug'# travis doenst like byebug
+# require 'byebug'# travis doenst like byebug
 require_relative '../lib/forty_facets'
 
 #silence_warnings do
@@ -190,6 +191,20 @@ class SmokeTest < Minitest::Test
 
     assert_equal movies_with_studio.size, search_with_studio.result.size
     assert_equal movies_with_studio.size, first_facet_value.count
+  end
+
+  def test_belongs_to_filter_with_default_scope
+    wrap_in_db_transaction do
+      deleted_studio = Studio.create!(name: 'Deleted studio', status: 'active')
+      movie = Movie.create!(studio: deleted_studio)
+      deleted_studio.update!(deleted_at: Time.now)
+
+      blank_search = MovieSearch.new
+
+      assert_equal(
+        5, blank_search.filter(:studio).facet.length
+      )
+    end
   end
 
   def test_sort_by_proc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,8 @@
+class Minitest::Test
+  def wrap_in_db_transaction(&block)
+    ActiveRecord::Base.transaction do
+      yield
+      raise ActiveRecord::Rollback
+    end
+  end
+end


### PR DESCRIPTION
I encountered a bug in the facet filter and solved it in this PR.

This bugs occurs when using a default_scope on an associated model and when
the association definition "unscopes" the default scope. I've added a test case
the clarify this. Before my fix was added this test failed with following error:

```
1) Error:                                                                            
SmokeTest#test_belongs_to_filter_with_default_scope:                                                                                                                           
ActiveRecord::RecordNotFound: Couldn't find all Studios with 'id': (1, 2, 3, 4, 5) [WHERE "studios"."deleted_at" IS NULL] (found 4 results, but was looking for 5).
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/relation/finder_methods.rb:351:in `raise_record_not_found_exception!'
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/relation/finder_methods.rb:496:in `find_some_ordered'
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/relation/finder_methods.rb:462:in `find_some'
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/relation/finder_methods.rb:438:in `find_with_ids'                                                              
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/relation/finder_methods.rb:69:in `find'
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/querying.rb:5:in `find'                                                                                        
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/core.rb:160:in `find'                                                                                          
  /myapp/lib/forty_facets/filter/facet_filter_definition.rb:104:in `facet'                                                                                                   
  test/smoke_test.rb:205:in `block in test_belongs_to_filter_with_default_scope'                                                                                             
  /myapp/test/test_helper.rb:4:in `block in wrap_in_db_transaction'                                                                                                          
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `block in transaction'
  /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:239:in `block in within_new_transaction'
    /usr/local/lib/ruby/2.5.0/monitor.rb:226:in `mon_synchronize'                                                                                                              
    /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/transaction.rb:236:in `within_new_transaction'                                    
    /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/connection_adapters/abstract/database_statements.rb:267:in `transaction'
    /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/transactions.rb:212:in `transaction'                                                                           
    /myapp/test/test_helper.rb:3:in `wrap_in_db_transaction'                                                                                                                   
    test/smoke_test.rb:197:in `test_belongs_to_filter_with_default_scope
```

My solution is to use `unscoped` when finding the facet records.